### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -17,7 +17,7 @@ jobs:
       
     - name: Publish with tag
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: elgohr/Publish-Docker-Github-Action@3.04
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ secrets.DOCKERHUB_USER }}/blaezi:${{ env.RELEASE_VERSION }}
         username: ${{ secrets.DOCKERHUB_USER }}
@@ -27,7 +27,7 @@ jobs:
         
     - name: Publish latest
       if: "!startsWith(github.ref, 'refs/tags/v')"
-      uses: elgohr/Publish-Docker-Github-Action@3.04
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ secrets.DOCKERHUB_USER }}/blaezi:latest
         username: ${{ secrets.DOCKERHUB_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore